### PR TITLE
Feature/add auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,11 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'json'
 gem 'http'
+
+# Auth
 gem 'bcrypt', '~> 3.1.7'
 gem 'jwt'
+gem 'simple_command'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'json'
 gem 'http'
+gem 'bcrypt', '~> 3.1.7'
+gem 'jwt'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    bcrypt (3.1.12)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -79,6 +80,7 @@ GEM
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
+    jwt (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -183,6 +185,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   database_cleaner
@@ -190,6 +193,7 @@ DEPENDENCIES
   faker
   http
   json
+  jwt
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
+    simple_command (0.0.9)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -200,6 +201,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.2)
   rspec-rails (~> 3.5)
+  simple_command
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/commands/authenticate_user.rb
+++ b/app/commands/authenticate_user.rb
@@ -1,0 +1,28 @@
+class AuthenticateUser
+  prepend SimpleCommand
+
+  def initialize(email, password)
+    @email = email
+    @password = password
+  end
+
+  def call
+    JsonWebToken.encode(user_id: user.id) if user.present?
+  end
+
+  private
+
+  attr_accessor :email, :password
+
+  def user
+    user = User.find_by_email(email)
+
+    if user.present? && user.authenticate(password)
+      return user
+    else
+      errors.add :user_authentication, 'invalid credentials'
+    end
+
+    nil
+  end
+end

--- a/app/commands/authorize_api_request.rb
+++ b/app/commands/authorize_api_request.rb
@@ -1,0 +1,33 @@
+class AuthorizeApiRequest
+  prepend SimpleCommand
+
+  def initialize(headers = {})
+    @headers = headers
+  end
+
+  def call
+    user
+  end
+
+  private
+
+  attr_reader :headers
+
+  def user
+    @user ||= User.find(decoded_auth_token[:user_id]) if decoded_auth_token
+    @user || errors.add(:token, 'Invalid token') && nil
+  end
+
+  def decoded_auth_token
+    @decoded_auth_token ||= JsonWebToken.decode(http_auth_header)
+  end
+
+  def http_auth_header
+    if headers['Authorization'].present?
+      return headers['Authorization'].split(' ').last
+    else
+      errors.add(:token, 'Missing token')
+    end
+    nil
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,14 @@
 class ApplicationController < ActionController::API
   include Response
   include ExceptionHandler
+
+  before_action :authenticate_request
+  attr_reader   :current_user
+
+  private
+
+  def authenticate_request
+    @current_user = AuthorizeApiRequest.call(request.headers).result
+    render json: { error: 'Not Authorized' }, status: 401 unless @current_user.present?
+  end
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,0 +1,13 @@
+class AuthenticationController < ApplicationController
+  skip_before_action :authenticate_request
+
+  def authenticate
+    command = AuthenticateUser.call(params[:email], params[:password])
+
+    if command.success?
+      render json: { auth_token: command.result }
+    else
+      render json: { error: command.errors }, status: :unauthorized
+    end
+  end
+end

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,0 +1,13 @@
+class JsonWebToken
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, Rails.application.secrets.secret_key_base)
+  end
+
+  def self.decode(token)
+    body = JWT.decode(token, Rails.application.secrets.secret_key_base).first
+    HashWithIndifferentAccess.new(body)
+  rescue
+    nil
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_secure_password
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  post 'authenticate', to: 'authentication#authenticate'
+
   namespace :api do
     namespace :v1 do
       get 'where_to_eat/options'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,21 @@
+local:             &local
+  secret_key_base: '5c1e90004cc45358eac49153e427ba278087c7c9be7a0b7c88cf6cd42eaaf22ab245023930eb77cc2239ae97ca435d00f9b24223b85da5017c289f9b46e7befe'
+
+test:
+  <<:              *local
+
+development:
+  <<:              *local
+
+
+deployed:          &deployed
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+staging:
+  <<:              *deployed
+
+production:
+  <<:              *deployed
+
+pentest:
+  <<:              *deployed

--- a/db/migrate/20190206032047_create_users.rb
+++ b/db/migrate/20190206032047_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_03_000256) do
+ActiveRecord::Schema.define(version: 2019_02_06_032047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,14 @@ ActiveRecord::Schema.define(version: 2019_02_03_000256) do
   create_table "searches", force: :cascade do |t|
     t.string "query"
     t.integer "query_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Overview

- Add JSON Web Tokens for Auth Purposes
- Workflow:
  - Get Token:
    - ```
        curl -H "Content-Type: application/json" -X POST -d '{"email":"example@mail.com","password":"notjustpassword"}' http://localhost:3000/authenticate`
        ```
    - `=> {"auth_token":"mytotallyawesometoken"}` . 
  - Add In Request Header:
    - ```
       curl -H "Authorization: mytotallyawesometoken" http://localhost:3000/api/v1/where_to_eat/just_tell_me
       ```
  - Fails with: `{"error":"Not Authorized"} # Status 401`

NOTES: 
  - `ENV['SECRET_KEY_BASE']` Needs to be set up for deployment
  - TO FUTURE ME:
    - Trying out the Call pattern with private accessors to see how it feels - it seems to becoming more popular. Maybe should consider converting the Yelp Service to this pattern. Creating a uniform interface does have its advantages.
